### PR TITLE
Update etcd to 3.5.3 

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -27,7 +27,9 @@ resource "aws_launch_configuration" "default" {
     peer_key_file                = tls_private_key.peer[count.index].private_key_pem,
     server_cert_file             = tls_locally_signed_cert.server[count.index].cert_pem,
     server_key_file              = tls_private_key.server[count.index].private_key_pem,
-    maintenance_day_of_the_month = count.index < 26 ? count.index + 1 : count.index - 25
+    maintenance_day_of_the_month = count.index < 26 ? count.index + 1 : count.index - 25,
+    aws_region                   = data.aws_region.current.name,
+    aws_dns_server               = cidrhost(data.aws_vpc.target.cidr_block, 2),
   })])
   root_block_device { encrypted = true }
 

--- a/cloudinit/userdata-template.sh
+++ b/cloudinit/userdata-template.sh
@@ -4,11 +4,11 @@ useradd -U -M -s /dev/null etcd
 mkdir -p /etc/ssl/etcd
 chown -R etcd:etcd /etc/ssl/etcd
 chmod -R 700 /etc/ssl/etcd
-curl -L -o /tmp/etcd-v"$etcd_version"-linux-amd64.tar.gz "$etcd_url"
+curl -L -o "/tmp/etcd-v${etcd_version}-linux-amd64.tar.gz" "${etcd_url}"
 
-tar xvf /tmp/etcd-v"$etcd_version"-linux-amd64.tar.gz -C /tmp
+tar xvf "/tmp/etcd-v${etcd_version}-linux-amd64.tar.gz" -C /tmp
 
-mv /tmp/etcd-v"$etcd_version"-linux-amd64/{etcd,etcdctl,etcdutl} /usr/local/bin
+mv "/tmp/etcd-v${etcd_version}-linux-amd64/"{etcd,etcdctl,etcdutl} /usr/local/bin
 
 mkdir -p /var/lib/etcd/
 chown -R etcd:etcd /var/lib/etcd

--- a/cloudinit/userdata-template.sh
+++ b/cloudinit/userdata-template.sh
@@ -1,40 +1,52 @@
 ## Install ETCD
 useradd -U -M -s /dev/null etcd
 
-mkdir -p /etc/ssl/etcd; chown -R etcd:etcd /etc/ssl/etcd; chmod -R 700 /etc/ssl/etcd
-curl -L -o /tmp/etcd-v${etcd_version}-linux-amd64.tar.gz ${etcd_url}
+mkdir -p /etc/ssl/etcd
+chown -R etcd:etcd /etc/ssl/etcd
+chmod -R 700 /etc/ssl/etcd
+curl -L -o /tmp/etcd-v"$etcd_version"-linux-amd64.tar.gz "$etcd_url"
 
-tar xvf /tmp/etcd-v${etcd_version}-linux-amd64.tar.gz -C /tmp
+tar xvf /tmp/etcd-v"$etcd_version"-linux-amd64.tar.gz -C /tmp
 
-mv /tmp/etcd-v${etcd_version}-linux-amd64/{etcd,etcdctl,etcdutl} /usr/local/bin
+mv /tmp/etcd-v"$etcd_version"-linux-amd64/{etcd,etcdctl,etcdutl} /usr/local/bin
 
 mkdir -p /var/lib/etcd/
 chown -R etcd:etcd /var/lib/etcd
 chmod -R 700 /var/lib/etcd
 mkdir -p /etc/etcd
 
-cat << EOT > /etc/systemd/system/etcd-member.service
+## Switch to AWS DNS direct rather than systemd-resolved
+systemctl disable systemd-resolved
+cat <<EOF >/etc/resolv.conf
+nameserver ${aws_dns_server}
+options edns0
+search ${aws_region}.compute.internal
+EOF
+chattr +i /etc/resolv.conf
+systemctl stop systemd-resolved
+
+cat <<EOT >/etc/systemd/system/etcd-member.service
 ${etcd_member_unit}
 EOT
 
 ## Create certificate files
-cat << EOT > /etc/ssl/etcd/ca.pem
+cat <<EOT >/etc/ssl/etcd/ca.pem
 ${ca_file}
 EOT
 
-cat << EOT > /etc/ssl/etcd/server.pem
+cat <<EOT >/etc/ssl/etcd/server.pem
 ${server_cert_file}
 EOT
 
-cat << EOT > /etc/ssl/etcd/server-key.pem
+cat <<EOT >/etc/ssl/etcd/server-key.pem
 ${server_key_file}
 EOT
 
-cat << EOT > /etc/ssl/etcd/peer.pem
+cat <<EOT >/etc/ssl/etcd/peer.pem
 ${peer_cert_file}
 EOT
 
-cat << EOT > /etc/ssl/etcd/peer-key.pem
+cat <<EOT >/etc/ssl/etcd/peer-key.pem
 ${peer_key_file}
 EOT
 
@@ -44,7 +56,7 @@ local_ipv4=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.25
 sed -e "s/~private_ipv4/$local_ipv4/g" -i /etc/systemd/system/etcd-member.service
 
 ## Create a cronjob to defrag etcd data, but be careful to spread out the time across all nodes to maintain service availability
-cat <<EOT> /etc/cron.d/defrag-etcd
+cat <<EOT >/etc/cron.d/defrag-etcd
 5 3 ${maintenance_day_of_the_month} * * root /usr/bin/sudo -u etcd ETCDCTL_API=3 ETCDCTL_CERT=/etc/ssl/etcd/server.pem ETCDCTL_KEY=/etc/ssl/etcd/server-key.pem ETCDCTL_ENDPOINTS="https://${etcd_endpoint}:2379" etcdctl defrag
 EOT
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "role" {
 }
 
 variable "etcd_version" {
-  default     = "3.5.1"
+  default     = "3.5.3"
   description = "etcd version to install"
 }
 


### PR DESCRIPTION
This updates etcd to v3.5.3 in accordance with modern guidance. It also resolves an issue where systemd-resolved doesn't work in the latest Ubuntu for EKS versions by disabling it and using direct resolve DNS entries to map to the AWS subnet's DNS server.